### PR TITLE
Feat: build xcframework

### DIFF
--- a/bindings/build.sh
+++ b/bindings/build.sh
@@ -9,11 +9,17 @@ release_dir="./target"
 rm -rf $output_dir
 mkdir -p $output_dir
 
+echo "Building .a libraries"
+
+cargo lipo --release
+
 # We need single folder with headers to put module map within it
 headers_temp_dir="./hydra-dx/headers"
 mkdir -p $headers_temp_dir
 cp "./hydra-dx/Generated/SwiftBridgeCore.h" $headers_temp_dir
 cp "./hydra-dx/Generated/hydra-dx/hydra-dx.h" $headers_temp_dir
+
+echo "Copied headers to temporary folder: $headers_temp_dir"
 
 # Create module.modulemap file
 cat <<EOF >$headers_temp_dir/module.modulemap
@@ -24,6 +30,9 @@ module ${lib_name} {
 }
 EOF
 
+echo "Created module map at: $headers_temp_dir/module.modulemap"
+
+# Here we need 2 lines (-library and -headers) for each architecture
 xcodebuild -create-xcframework \
     -library $release_dir/aarch64-apple-ios/release/lib${lib_name}.a \
     -headers $headers_temp_dir \

--- a/bindings/build.sh
+++ b/bindings/build.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -e
+
+lib_name="hydra_dx"
+output_dir="./xcframework"
+release_dir="./target"
+
+rm -rf $output_dir
+mkdir -p $output_dir
+
+# We need single folder with headers to put module map within it
+headers_temp_dir="./hydra-dx/headers"
+mkdir -p $headers_temp_dir
+cp "./hydra-dx/Generated/SwiftBridgeCore.h" $headers_temp_dir
+cp "./hydra-dx/Generated/hydra-dx/hydra-dx.h" $headers_temp_dir
+
+# Create module.modulemap file
+cat <<EOF >$headers_temp_dir/module.modulemap
+module ${lib_name} {
+    header "SwiftBridgeCore.h"
+    header "hydra-dx.h"
+    export *
+}
+EOF
+
+xcodebuild -create-xcframework \
+    -library $release_dir/aarch64-apple-ios/release/lib${lib_name}.a \
+    -headers $headers_temp_dir \
+    -library $release_dir/x86_64-apple-ios/release/lib${lib_name}.a \
+    -headers $headers_temp_dir \
+    -output $output_dir/${lib_name}.xcframework
+
+echo "XCFramework created at $output_dir/${lib_name}.xcframework"
+
+rm -rf $headers_temp_dir
+
+echo "Cleanup finished"


### PR DESCRIPTION
## Purpose
Support creation of xcframework that can be used later on as base for CP / SPM dependency.

## Usage
cd bindings
./build.sh

## Results
.xcframework file with properly aligned headers and .modulemap which is needed to properly see public interface

![CleanShot 2024-05-07 at 15 45 49@2x](https://github.com/novasamatech/hydra-math-swift/assets/1955364/e8fd2a5a-ee17-473d-b624-4d88d4eaecbc)

![CleanShot 2024-05-07 at 15 45 56@2x](https://github.com/novasamatech/hydra-math-swift/assets/1955364/d153b1e3-63b8-4277-80d2-af4fa28cbe86)

## Next steps
Now that there is xcframework, it still should be used along `Stableswap.swift` and `SwiftBridgeCore.swift` files, as they wrap direct Rust bridging interface
Now either podspec or spm package definition can be created to use this as library